### PR TITLE
Publish reproducible safety frontier evidence

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run evidence:frontier
+      - run: git diff --exit-code -- docs/evidence/economy-frontier.json
       - run: npm run format:check
       - run: npm run lint
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ intends to use semantic versioning after the first public release.
 ### Added
 
 - Public contribution, security, support, evaluation, and release processes.
+- Reproducible, CI-checked public evidence for 240 deterministic safety-frontier
+  cases.
 
 ### Changed
 
-- None.
+- Clarified the boundary between local safety evidence and live-model
+  performance claims.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ configurations, or unreviewed recordings.
 
 The release includes a sanitized, reproducible
 [credential-free smoke-test result](docs/evidence/mock-benchmark-v0.1.0.json).
+The current source also publishes a CI-checked
+[240-case safety-frontier result](docs/evidence/economy-frontier.json) covering
+risk classification, fail-closed protocol handling, path confinement, exact
+patch lowering, and the live-evaluation budget guard. Reproduce it with
+`npm run evidence:frontier`. These are deterministic local checks, not live
+model results or evidence of token savings.
 
 ## Contributing
 

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -21,3 +21,21 @@ See [`mock-benchmark-v0.1.0.json`](mock-benchmark-v0.1.0.json) for the sanitized
 release-candidate result. Timing fields are omitted because a single local run
 does not support a performance claim. The full evaluation standard remains in
 [`docs/evaluation.md`](../evaluation.md).
+
+## Reproduce the safety frontier
+
+From a source checkout with dependencies installed:
+
+```sh
+npm run evidence:frontier
+```
+
+The command executes 240 deterministic cases covering task-risk classification,
+fail-closed provider responses, repository path confinement, exact patch
+lowering, and the live-evaluation budget guard. It then regenerates the
+sanitized [`economy-frontier.json`](economy-frontier.json) summary. CI rejects a
+change when the checked-in summary no longer matches the executable cases.
+
+This evidence makes no model call. It validates local safety and control
+behavior; it does not establish model quality or token, latency, or cost
+savings.

--- a/docs/evidence/economy-frontier.json
+++ b/docs/evidence/economy-frontier.json
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": 1,
+  "evidenceType": "credential-free-safety-frontier",
+  "command": "npm run evidence:frontier",
+  "source": "tests/economy-frontier.test.ts",
+  "modelCall": false,
+  "status": "passed",
+  "totals": {
+    "cases": 240,
+    "passed": 240,
+    "failed": 0,
+    "skipped": 0
+  },
+  "groups": [
+    {
+      "name": "economy frontier: task risk never silently downgrades",
+      "total": 48,
+      "passed": 48,
+      "failed": 0
+    },
+    {
+      "name": "economy frontier: provider protocol remains fail-closed",
+      "total": 48,
+      "passed": 48,
+      "failed": 0
+    },
+    {
+      "name": "economy frontier: repository path confinement",
+      "total": 48,
+      "passed": 48,
+      "failed": 0
+    },
+    {
+      "name": "economy frontier: exact patch lowering",
+      "total": 48,
+      "passed": 48,
+      "failed": 0
+    },
+    {
+      "name": "economy frontier: ten-percent live budget is fail-closed",
+      "total": 48,
+      "passed": 48,
+      "failed": 0
+    }
+  ],
+  "limitations": [
+    "These are deterministic unit and contract cases, not live model runs.",
+    "This is project-maintainer evidence, not an independent evaluation.",
+    "The result does not establish model quality, token, latency, or cost savings."
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build": "tsc",
     "test": "vitest run",
     "test:frontier": "vitest run tests/economy-frontier.test.ts",
+    "evidence:frontier": "node scripts/generate-frontier-evidence.mjs",
     "eval:quota": "npm run build --silent && node dist/eval-budget-cli.js snapshot",
     "eval:budget:init": "npm run build --silent && node dist/eval-budget-cli.js init",
     "eval:budget:status": "npm run build --silent && node dist/eval-budget-cli.js status",

--- a/scripts/generate-frontier-evidence.mjs
+++ b/scripts/generate-frontier-evidence.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const temporaryRoot = mkdtempSync(join(tmpdir(), 'lattice-frontier-evidence-'));
+const rawReportPath = join(temporaryRoot, 'vitest.json');
+const outputPath = resolve(root, 'docs/evidence/economy-frontier.json');
+const vitestPath = resolve(root, 'node_modules/vitest/vitest.mjs');
+
+try {
+  const result = spawnSync(
+    process.execPath,
+    [
+      vitestPath,
+      'run',
+      'tests/economy-frontier.test.ts',
+      '--reporter=json',
+      `--outputFile=${rawReportPath}`,
+    ],
+    { cwd: root, encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout ?? '');
+    process.stderr.write(result.stderr ?? '');
+    process.exit(result.status ?? 1);
+  }
+
+  const report = JSON.parse(readFileSync(rawReportPath, 'utf8'));
+  const assertions = report.testResults.flatMap(
+    (testResult) => testResult.assertionResults,
+  );
+  const groups = new Map();
+  for (const assertion of assertions) {
+    const name = assertion.ancestorTitles[0] ?? 'ungrouped';
+    const group = groups.get(name) ?? { name, total: 0, passed: 0, failed: 0 };
+    group.total += 1;
+    if (assertion.status === 'passed') group.passed += 1;
+    else group.failed += 1;
+    groups.set(name, group);
+  }
+
+  const evidence = {
+    schemaVersion: 1,
+    evidenceType: 'credential-free-safety-frontier',
+    command: 'npm run evidence:frontier',
+    source: 'tests/economy-frontier.test.ts',
+    modelCall: false,
+    status: report.success ? 'passed' : 'failed',
+    totals: {
+      cases: report.numTotalTests,
+      passed: report.numPassedTests,
+      failed: report.numFailedTests,
+      skipped: report.numPendingTests + report.numTodoTests,
+    },
+    groups: [...groups.values()],
+    limitations: [
+      'These are deterministic unit and contract cases, not live model runs.',
+      'This is project-maintainer evidence, not an independent evaluation.',
+      'The result does not establish model quality, token, latency, or cost savings.',
+    ],
+  };
+
+  if (
+    evidence.totals.cases !== 240 ||
+    evidence.totals.passed !== 240 ||
+    evidence.totals.failed !== 0 ||
+    evidence.groups.length !== 5
+  ) {
+    throw new Error('frontier evidence shape changed; review before publishing');
+  }
+
+  writeFileSync(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+  process.stdout.write(
+    `Frontier evidence passed: ${evidence.totals.passed}/${evidence.totals.cases} cases\n`,
+  );
+  process.stdout.write(`Sanitized report: ${outputPath}\n`);
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/src/sidecar.ts
+++ b/src/sidecar.ts
@@ -1154,6 +1154,27 @@ export async function ensureSidecar(
       signal: options.signal,
     });
   } catch (error) {
+    options.signal?.throwIfAborted();
+    // Two launchers can observe an empty repository state and spawn at the
+    // same time. The child that loses the exclusive lock exits, so attach its
+    // parent to the healthy winner instead of degrading that native session.
+    if (existsSync(paths.lock) && lockOwnerIsAlive(paths.lock)) {
+      try {
+        const state = await waitForSidecar(
+          paths,
+          startupTimeoutMs,
+          binding,
+          options.signal,
+        );
+        return await attachSidecar(state, {
+          heartbeat: options.heartbeat,
+          clientKind: options.clientKind,
+          signal: options.signal,
+        });
+      } catch {
+        options.signal?.throwIfAborted();
+      }
+    }
     // Launcher cancellation is expected when a short native command exits.
     // The detached service owns its bounded idle shutdown; waiting on taskkill
     // here would make `codex --version` wait for optional infrastructure.

--- a/tests/codex-cli-passthrough.test.ts
+++ b/tests/codex-cli-passthrough.test.ts
@@ -500,14 +500,17 @@ describe('transparent Codex CLI passthrough', () => {
 
       const paths = sidecarPaths(value.workspace);
       const deadline = Date.now() + 10_000;
-      while (existsSync(paths.state) && Date.now() < deadline) {
+      while (
+        (existsSync(paths.state) || existsSync(paths.lock)) &&
+        Date.now() < deadline
+      ) {
         await new Promise((resolveWait) => setTimeout(resolveWait, 40));
       }
       expect(existsSync(paths.state)).toBe(false);
       expect(existsSync(paths.lock)).toBe(false);
       expect(existsSync(paths.telemetry)).toBe(true);
     },
-    30_000,
+    40_000,
   );
 
   test(
@@ -562,21 +565,21 @@ describe('transparent Codex CLI passthrough', () => {
       const sharedEnvironment = {
         FAKE_CODEX_ECHO_STDIN: '0',
         FAKE_CODEX_WAIT_FOR_FILE: join(value.root, 'release-native-sessions'),
-        FAKE_CODEX_WAIT_FOR_FILE_TIMEOUT_MS: '20000',
+        FAKE_CODEX_WAIT_FOR_FILE_TIMEOUT_MS: '30000',
         LATTICE_SIDECAR_IDLE_MS: '3000',
         LATTICE_SIDECAR_LEASE_TTL_MS: '5000',
       };
 
       const first = runCli(['--session', 'one'], {
         env: sharedEnvironment,
-        timeoutMs: 20_000,
+        timeoutMs: 30_000,
       });
       const second = runCli(['--session', 'two'], {
         env: sharedEnvironment,
-        timeoutMs: 20_000,
+        timeoutMs: 30_000,
       });
       const paths = sidecarPaths(value.workspace);
-      const deadline = Date.now() + 10_000;
+      const deadline = Date.now() + 20_000;
       let observed:
         | { pid: number; activeLeases: number; repositoryId: string }
         | undefined;
@@ -614,7 +617,7 @@ describe('transparent Codex CLI passthrough', () => {
       expect(existsSync(paths.state)).toBe(false);
       expect(existsSync(paths.lock)).toBe(false);
     },
-    30_000,
+    45_000,
   );
 
   test('injects routing instructions when integrated inside a safe repository', async () => {

--- a/tests/sidecar-lifecycle.test.ts
+++ b/tests/sidecar-lifecycle.test.ts
@@ -125,6 +125,28 @@ describe('managed sidecar process lifecycle', () => {
   );
 
   test(
+    'attaches concurrent bootstrappers to the same winning sidecar',
+    async () => {
+      const fixture = await fixtureRepository('concurrent-bootstrap');
+      repositories.push(fixture);
+
+      const [first, second] = await Promise.all([
+        managedLease(fixture),
+        managedLease(fixture),
+      ]);
+
+      expect(first.state.pid).toBe(second.state.pid);
+      expect(first.state.repositoryId).toBe(second.state.repositoryId);
+      await eventually(async () => {
+        const status = await sidecarStatus(fixture.path);
+        expect(status.running).toBe(true);
+        expect(status.state?.activeLeases).toBe(2);
+      });
+    },
+    30_000,
+  );
+
+  test(
     'keeps a newborn sidecar alive long enough for its first authenticated attach',
     async () => {
       const fixture = await fixtureRepository('startup-grace');


### PR DESCRIPTION
## What changed

- add a deterministic evidence generator for the existing safety-frontier suite
- publish a sanitized 240-case result grouped by five control boundaries
- make CI regenerate the artifact and reject stale checked-in evidence
- document exactly what the result does and does not demonstrate
- fix a concurrent sidecar bootstrap race by attaching the losing launcher to the healthy lock winner
- add regression coverage and make asynchronous lifecycle assertions wait for complete state transitions

## Why

Lattice already had executable safety and control cases, but no concise public artifact connecting those cases to a reproducible result. This makes the evidence inspectable without presenting local tests as a live-model benchmark.

The initial CI run also exposed a real race when two launchers bootstrapped the same repository simultaneously. The process that lost the exclusive lock could degrade instead of attaching to the healthy winner.

## Impact

Maintainers and reviewers can run `npm run evidence:frontier` and verify the same 240/240 result. Concurrent native sessions now converge on one repository sidecar and retain independent leases.

The published JSON contains no model conversations, provider sessions, private paths, or timing claims.

## Validation

- `npm run evidence:frontier` — 240/240 passed
- `npm test` — 423 passed, 2 skipped
- concurrent sidecar regression sets — 5 consecutive passes
- `npm run format:check`
- `npm run lint`
- `npm run package:check`
- public-export scan — passed
- all 17 GitHub checks — passed
