### PR TITLE
Prepare v0.1.1 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: Lattice version
-      placeholder: "0.1.0 or commit SHA"
+      placeholder: "0.1.1 or commit SHA"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,9 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
-      - run: npm test
+      - name: Run tests
+        if: runner.os != 'Windows'
+        run: npm test
+      - name: Run process-heavy tests serially on Windows
+        if: runner.os == 'Windows'
+        run: npm test -- --maxWorkers=1 --no-file-parallelism

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,33 @@ intends to use semantic versioning after the first public release.
 
 ### Added
 
-- Public contribution, security, support, evaluation, and release processes.
+- None.
+
+### Changed
+
+- None.
+
+### Security
+
+- None.
+
+## [0.1.1] - 2026-08-02
+
+### Added
+
 - Reproducible, CI-checked public evidence for 240 deterministic safety-frontier
   cases.
+- Regression coverage for simultaneous sidecar bootstrap attempts.
 
 ### Changed
 
 - Clarified the boundary between local safety evidence and live-model
   performance claims.
 
-### Security
+### Fixed
 
-- None.
+- Concurrent launchers now attach to the healthy repository sidecar after a
+  competing bootstrap process loses the exclusive lock.
 
 ## [0.1.0] - 2026-08-01
 
@@ -49,5 +64,6 @@ intends to use semantic versioning after the first public release.
 - Other provider adapters are not included.
 - Public CLI, MCP, and persistence compatibility is not stable before 1.0.
 
-[Unreleased]: https://github.com/moulwyse/lattice/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/moulwyse/lattice/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/moulwyse/lattice/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/moulwyse/lattice/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ You need [Git](https://git-scm.com/downloads) and a supported
 [Node.js](https://nodejs.org/en/download) version (`20.19+` or `22.12+`). You
 do not need an API key to install Lattice or run its local demo.
 
-### Install the v0.1.0 GitHub release
+### Install the v0.1.1 GitHub release
 
 The release tarball gives Windows, macOS, and Linux users one npm-managed
 installation command without requiring an npm registry publication:
 
 ```sh
-npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.0/lattice-v2-0.1.0.tgz
+npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.1/lattice-v2-0.1.1.tgz
 lattice --version
 lattice benchmark --worker mock
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ This guide covers the GitHub release package and source installation. For most
 people, the short version is:
 
 ```sh
-npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.0/lattice-v2-0.1.0.tgz
+npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.1/lattice-v2-0.1.1.tgz
 lattice benchmark --worker mock
 ```
 
@@ -40,7 +40,7 @@ The release tarball is produced by `npm pack` from the tagged commit and
 attached to the matching GitHub release. Install or upgrade it with:
 
 ```sh
-npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.0/lattice-v2-0.1.0.tgz
+npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.1/lattice-v2-0.1.1.tgz
 ```
 
 Verify the command and run the no-model smoke test:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,7 +5,7 @@ This path exercises Lattice without a model account or private repository.
 ## 1. Install the release
 
 ```sh
-npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.0/lattice-v2-0.1.0.tgz
+npm install --global https://github.com/moulwyse/lattice/releases/download/v0.1.1/lattice-v2-0.1.1.tgz
 ```
 
 Or clone the repository and build the exact source:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lattice-v2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lattice-v2",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@openai/codex-sdk": "^0.144.5",
         "commander": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lattice-v2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Bounded, auditable repository context and verified patch execution for coding agents.",
   "type": "module",

--- a/tests/public-metadata.test.ts
+++ b/tests/public-metadata.test.ts
@@ -19,7 +19,7 @@ describe('public release metadata', () => {
       repository: { url: string };
     };
 
-    expect(packageJson.version).toBe('0.1.0');
+    expect(packageJson.version).toBe('0.1.1');
     expect(packageJson.private).toBe(true);
     expect(packageJson.license).toBe('Apache-2.0');
     expect(packageJson.author).toEqual({


### PR DESCRIPTION
## Summary

- bump the public package and installation references to `v0.1.1`
- document the concurrent sidecar bootstrap recovery shipped since `v0.1.0`
- publish the 240-case deterministic safety evidence as part of a named patch release
- serialize process-heavy test files on Windows CI to remove runner contention

## Why

The runtime safety fix and its public evidence are already on `main`. This PR gives users an installable, traceable patch release whose version, docs, changelog, and metadata agree.

During the release gate, duplicate Windows CI runs exposed nondeterministic process-test timeouts under parallel file execution. Windows now runs the same suite with one worker; Linux and macOS remain parallel.

## Validation

- `npm test`: 423 passed, 2 skipped
- Windows-equivalent serial run: 423 passed, 2 skipped
- `npm run evidence:frontier`: 240/240 cases passed
- `npm run lint`
- `npm run format:check`
- `npm run package:check`

This release does not claim live-model benchmark results or measured token savings.
