### PR TITLE
Sync Claude OSS install command

### DIFF
--- a/docs/claude-for-oss.md
+++ b/docs/claude-for-oss.md
@@ -63,7 +63,7 @@ paths, credentials, and private source remain excluded from public evidence.
 ## Install and inspect
 
 ```sh
-npm install --global https://github.com/moulwyse/lattice/releases/download/v0.2.0-claude-beta.1/lattice-v2-0.2.0-claude-beta.1.tgz
+npm install --global github:moulwyse/lattice#v0.2.0-claude-beta.1
 lattice benchmark --worker mock
 lattice integration claude enable --workspace .
 lattice claude


### PR DESCRIPTION
﻿## What changed

Replaces the obsolete direct release `.tgz` URL in `docs/claude-for-oss.md` with the same GitHub npm install command used by the README and installation guides:

```sh
npm install --global github:moulwyse/lattice#v0.2.0-claude-beta.1
```

## Why

The OSS brief had drifted from the current one-command installation path and could send evaluators through an older package URL.

## Validation

- Confirmed the install command now matches README, `docs/installation.md`, and `docs/quick-start.md`
- `npm run format:check`
- `git diff --check`
